### PR TITLE
Explicitly link against libshared

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -65,7 +65,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be columnlistview translation tracker $(STDCPPLIBS)
+LIBS = shared be columnlistview translation tracker $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative


### PR DESCRIPTION
Fixes the "missing symbols" issue after hrev56577.

This is basically just trying to upstream the patchset on Haikuports.